### PR TITLE
fix: update bpmn-js and fix issue #6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowsquad/flowcov-viewer",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Contains the viewer for the flowcov.io frontend",
     "author": "FlowSquad GmbH <info@flowsquad.io>",
     "homepage": "..",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.60",
-        "bpmn-js": "^8.8.2",
+        "bpmn-js": "13.1.0",
         "camunda-bpmn-moddle": "^6.1.1",
         "clsx": "^1.1.1",
-        "jquery": "^3.6.0",
+        "jquery": "3.6.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
     },

--- a/src/components/Viewer/BpmnViewer.tsx
+++ b/src/components/Viewer/BpmnViewer.tsx
@@ -199,14 +199,14 @@ const BpmnViewer: React.FC<Props> = props => {
                         }
 
                         if (props.showExpressions) {
-                            if (element.businessObject.extensionElements
-                                && element.businessObject.extensionElements.values) {
+                            if (element.businessObject.extensionElements?.values) {
                                 const extensionElements: ModdleElement[] = element
                                     .businessObject.extensionElements.values;
                                 extensionElements.forEach(extensionElement => {
                                     const { $type, event, fields } = extensionElement;
 
-                                    if ($type === "camunda:ExecutionListener" && (event === "end" || event === "start") && fields) {
+                                    const executionListener = "camunda:executionListener";
+                                    if ($type.toLowerCase() === executionListener.toLowerCase() && (event === "end" || event === "start") && fields) {
                                         fields.forEach((field: { expression: any; }) => {
                                             const position = {
                                                 bottom: 0,

--- a/src/components/Viewer/BpmnViewer.tsx
+++ b/src/components/Viewer/BpmnViewer.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import $ from "jquery";
 import React, { useEffect, useMemo } from "react";
 import camundaModdleDescriptor from "camunda-bpmn-moddle/resources/camunda.json";
+import { ModdleElement } from "bpmn-js/lib/model/Types";
 
 export interface BpmnViewerData {
     highlightSequenceFlows: string[];
@@ -198,31 +199,26 @@ const BpmnViewer: React.FC<Props> = props => {
                         }
 
                         if (props.showExpressions) {
-                            if (element.businessObject.extensionElements) {
-                                const extensionElements = element
+                            if (element.businessObject.extensionElements
+                                && element.businessObject.extensionElements.values) {
+                                const extensionElements: ModdleElement[] = element
                                     .businessObject.extensionElements.values;
-                                for (let j = 0; j < extensionElements.length; j++) {
-                                    if (extensionElements[j].$type === "camunda:executionListener") {
-                                        if (extensionElements[j].event === "end") {
-                                            overlays.add(element.id, "note", {
-                                                position: {
-                                                    bottom: 0,
-                                                    right: 0
-                                                },
-                                                html: `<div class='${classes.executionListener}'>${extensionElements[j].expression}</div>`
-                                            });
-                                        }
-                                        if (extensionElements[j].event === "start") {
-                                            overlays.add(element.id, "note", {
-                                                position: {
-                                                    bottom: 0,
-                                                    left: 0
-                                                },
-                                                html: `<div class='${classes.executionListener}'>${extensionElements[j].expression}</div>`
-                                            });
-                                        }
+                                extensionElements.forEach(extensionElement => {
+                                    const { $type, event, fields } = extensionElement;
+
+                                    if ($type === "camunda:ExecutionListener" && (event === "end" || event === "start") && fields) {
+                                        fields.forEach((field: { expression: any; }) => {
+                                            const position = {
+                                                bottom: 0,
+                                                [event === "end" ? "right" : "left"]: 0
+                                            };
+
+                                            const html = `<div class='${classes.executionListener}'>${field.expression}</div>`;
+
+                                            overlays.add(element.id, "note", { position, html });
+                                        });
                                     }
-                                }
+                                });
                             }
 
                             if (element.type === "bpmn:SequenceFlow"

--- a/src/components/Viewer/RunSummary.tsx
+++ b/src/components/Viewer/RunSummary.tsx
@@ -157,7 +157,7 @@ const RunSummary: React.FC<Props> = props => {
                     )}
 
                     {props.selectedSuite.models.map(model => (
-                        <>
+                        <React.Fragment key={model.key}>
                             <RunSummaryRow
                                 type="model"
                                 selected={props.selectedModel === model}
@@ -173,7 +173,7 @@ const RunSummary: React.FC<Props> = props => {
                                     model={run}
                                     onClick={() => props.onRunSelected(run)} />
                             ))}
-                        </>
+                        </React.Fragment>
                     ))}
 
                     <tr className={classes.spacingRow} key="spacing2">

--- a/src/components/Viewer/ViewerContainer.tsx
+++ b/src/components/Viewer/ViewerContainer.tsx
@@ -235,6 +235,7 @@ const ViewerContainer: React.FC = () => {
                         {parsedSuites.map(suite => (
                             <div
                                 onClick={() => setSelectedSuiteId(suite.id)}
+                                key={suite.id}
                                 className={clsx(
                                     classes.item,
                                     selectedSuiteId === suite.id && classes.itemSelected

--- a/src/components/Viewer/ViewerContainer.tsx
+++ b/src/components/Viewer/ViewerContainer.tsx
@@ -261,6 +261,7 @@ const ViewerContainer: React.FC = () => {
                         {selectedSuite.models.map(model => (
                             <div
                                 onClick={() => setSelectedModelKey(model.key)}
+                                key={model.key}
                                 className={clsx(
                                     classes.item,
                                     selectedModelKey === model.key && classes.itemSelected
@@ -289,6 +290,7 @@ const ViewerContainer: React.FC = () => {
                         {selectedModel.runs.map(run => (
                             <div
                                 onClick={() => setSelectedRunId(run.id)}
+                                key={run.id}
                                 className={clsx(
                                     classes.item,
                                     selectedRunId === run.id && classes.itemSelected

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,6 +1,6 @@
-import { createMuiTheme } from "@material-ui/core/styles";
+import { createTheme } from "@material-ui/core/styles";
 
-const theme = createMuiTheme({
+const theme = createTheme({
     palette: {
         primary: {
             light: "#32d35c",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,6 +1935,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@bpmn-io/diagram-js-ui@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.2.tgz#f182476e820641901c10d0079dcfe7b5b022b9f6"
+  integrity sha512-IgOIxOwoqsFB2mMPdXtcbPVPjdYkZ3huW7ipowYLhg5jdRGHlBronQ+LER+lfWro6sPtzEsw7qX8D8Yq9M2S5g==
+  dependencies:
+    htm "^3.1.1"
+    preact "^10.11.2"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -3704,30 +3712,29 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bpmn-js@^8.8.2:
-  version "8.8.2"
-  resolved "https://registry.yarnpkg.com/bpmn-js/-/bpmn-js-8.8.2.tgz#221666650ddc839bea2031d418d90bdf6e0ded2a"
-  integrity sha512-PnnbYxnQ2btaUzayI+vM9JOdCal46rjSOctjg0Op4psUr7/AIzTnN2/d7BvbeetLZ1GaZ2Z5DmWxIOcsabQZdQ==
+bpmn-js@13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/bpmn-js/-/bpmn-js-13.1.0.tgz#a946c1c6da2bdaabe1e62d38cd1324ad7d8426cb"
+  integrity sha512-tnINF2cUyprOXTZmOsj9dNysW7Se4rAYxSuC+VCcXwHU0Vn+9+147vihg5hi4gbQaIoriRhiNSlCivxXS3FikA==
   dependencies:
-    bpmn-moddle "^7.1.2"
-    css.escape "^1.5.1"
-    diagram-js "^7.5.0"
-    diagram-js-direct-editing "^1.6.3"
+    bpmn-moddle "^8.0.0"
+    diagram-js "^12.1.0"
+    diagram-js-direct-editing "^2.0.0"
     ids "^1.0.0"
-    inherits "^2.0.4"
-    min-dash "^3.5.2"
-    min-dom "^3.1.3"
+    inherits-browser "^0.1.0"
+    min-dash "^4.0.0"
+    min-dom "^4.0.3"
     object-refs "^0.3.0"
-    tiny-svg "^2.2.2"
+    tiny-svg "^3.0.0"
 
-bpmn-moddle@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/bpmn-moddle/-/bpmn-moddle-7.1.2.tgz#0a23046f67e43c5e37b9c9f6800de070f3e81df4"
-  integrity sha512-Sax4LokRCTqlg26njjULN3ZGtCmwH5gZVUZTRF0jwJk+YpMQhSfSoUECxjNv8OROoLxu8Z+MjdOHIxgvJf7KwA==
+bpmn-moddle@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/bpmn-moddle/-/bpmn-moddle-8.0.1.tgz#ba8a009fbd354fb521a11a1dd1417655a9d2ec02"
+  integrity sha512-mwZcrWhi52+JH5Oq58WwKYcUxQ1ZMiDQuzt1bpqiqEEFFnQLqCgtLwEXQuDXFmAuQPdMAghyPzqdOZQqIQVesw==
   dependencies:
-    min-dash "^3.5.2"
-    moddle "^5.0.2"
-    moddle-xml "^9.0.5"
+    min-dash "^4.0.0"
+    moddle "^6.0.0"
+    moddle-xml "^10.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -4208,6 +4215,11 @@ clsx@^1.0.4, clsx@^1.1.1:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
 
+clsx@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -4312,10 +4324,10 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
-component-event@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/component-event/-/component-event-0.1.4.tgz#3de78fc28782381787e24bf2a7c536bf0142c9b4"
-  integrity sha1-PeePwoeCOBeH4kvyp8U2vwFCybQ=
+component-event@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/component-event/-/component-event-0.2.1.tgz#8262d2be886c999ad4b85ed3e0dfb3b3e98ca9d3"
+  integrity sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==
 
 compose-function@3.0.3:
   version "3.0.3"
@@ -4695,11 +4707,6 @@ css-what@^3.2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
   integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
 
-css.escape@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
-  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
-
 css@^2.0.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
@@ -5015,33 +5022,34 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
-diagram-js-direct-editing@^1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/diagram-js-direct-editing/-/diagram-js-direct-editing-1.6.3.tgz#e7c59d7ac395439728f8da155f93510c58740c48"
-  integrity sha512-OwDpK4cNJ4QYuV855HvtZcB9/krfZRQ80uaE6bwaKbyb4584sD7nCtR5yWOyhJx4dIh1gMoqhF7d7G57M4tQVQ==
+diagram-js-direct-editing@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/diagram-js-direct-editing/-/diagram-js-direct-editing-2.0.0.tgz#0c7ec8ba2e3bad79bb97384e6acc522a225c07b1"
+  integrity sha512-/12OWL0B0RMCfaT1w3723c729MD42r5fay4wtm2DvxNFNBMdPaEvOHCTA/khLKjFzOzMVKxSzbAp7IEwBGonVw==
   dependencies:
-    min-dash "^3.5.2"
-    min-dom "^3.1.3"
+    min-dash "^4.0.0"
+    min-dom "^4.0.2"
 
-diagram-js@^7.5.0:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/diagram-js/-/diagram-js-7.6.0.tgz#9335dbb2f8991512e67485cbc9fd98868b2287ac"
-  integrity sha512-at6PPokklB5wl1xzyaBV3OF4Q79zdv1ptleTVHm0ut0ygIUuOMu7cHnJfhImeau5mknToRLQ/Ru+TsCZuG7BvA==
+diagram-js@^12.1.0:
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/diagram-js/-/diagram-js-12.1.1.tgz#338b5286160b57bbda2de5488e6b6abc06cf27c1"
+  integrity sha512-u0k8THfcDDSJLcJgqNFpZtoFRSK9xPpHyEbMonCobgwzWve0mD6ANsDIZYC5aXnHzlqeqD3OvFIGdG2+ToE2Rw==
   dependencies:
-    css.escape "^1.5.1"
-    didi "^5.2.1"
+    "@bpmn-io/diagram-js-ui" "^0.2.2"
+    clsx "^1.2.1"
+    didi "^9.0.2"
     hammerjs "^2.0.1"
-    inherits "^2.0.4"
-    min-dash "^3.5.2"
-    min-dom "^3.1.3"
+    inherits-browser "^0.1.0"
+    min-dash "^4.1.0"
+    min-dom "^4.1.0"
     object-refs "^0.3.0"
     path-intersection "^2.2.1"
-    tiny-svg "^2.2.2"
+    tiny-svg "^3.0.1"
 
-didi@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/didi/-/didi-5.2.1.tgz#1a0b1336be8baa0b068a72036eedd9fb94135bff"
-  integrity sha512-IKNnajUlD4lWMy/Q9Emkk7H1qnzREgY4UyE3IhmOi/9IKua0JYtYldk928bOdt1yNxN8EiOy1sqtSozEYsmjCg==
+didi@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/didi/-/didi-9.0.2.tgz#e49a80aa281b5672e45519ba1980d7fba2e32cfb"
+  integrity sha512-q2+aj+lnJcUweV7A9pdUrwFr4LHVmRPwTmQLtHPFz4aT7IBoryN6Iy+jmFku+oIzr5ebBkvtBCOb87+dJhb7bg==
 
 diff-sequences@^26.6.2:
   version "26.6.2"
@@ -5158,10 +5166,10 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domify@^1.3.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/domify/-/domify-1.4.0.tgz#11483617f764f8695975b4bdc79b14f0803b629b"
-  integrity sha1-EUg2F/dk+GlZdbS9x5sU8IA7Yps=
+domify@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/domify/-/domify-1.4.1.tgz#2e1e813019646715deeb8d3c5de4d3ef7bddd07e"
+  integrity sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w==
 
 domutils@1.5.1:
   version "1.5.1"
@@ -6530,6 +6538,11 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
+htm@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/htm/-/htm-3.1.1.tgz#49266582be0dc66ed2235d5ea892307cc0c24b78"
+  integrity sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==
+
 html-comment-regex@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
@@ -6789,11 +6802,6 @@ indexes-of@^1.0.1:
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
   integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
 
-indexof@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
-  integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
-
 infer-owner@^1.0.3, infer-owner@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
@@ -6806,6 +6814,11 @@ inflight@^1.0.4:
   dependencies:
     once "^1.3.0"
     wrappy "1"
+
+inherits-browser@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/inherits-browser/-/inherits-browser-0.1.0.tgz#893a7c9cc78f2a1e18093aaa203bbb8cf5c30511"
+  integrity sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==
 
 inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
@@ -7692,10 +7705,10 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
-jquery@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+jquery@3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.2.tgz#8302bbc9160646f507bdf59d136a478b312783c4"
+  integrity sha512-/e7ulNIEEYk1Z/l4X0vpxGt+B/dNsV8ghOPAWZaJs8pkGvsSC0tm33aMGylXcj/U7y4IcvwtMXPMyBFZn/gK9A==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -8179,11 +8192,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-matches-selector@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/matches-selector/-/matches-selector-1.2.0.tgz#d1814e7e8f43e69d22ac33c9af727dc884ecf12a"
-  integrity sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA==
-
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -8316,20 +8324,24 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-min-dash@^3.0.0, min-dash@^3.5.2:
+min-dash@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/min-dash/-/min-dash-3.5.2.tgz#23786fa289116ba3656038e16511577413d27200"
   integrity sha512-YVbJZUtnzT5QsgJUp9H9uyJTW6NJgswFqI27RI/+MSox860uIjaGMbSQBftEzbMXiJVRG24hpoIh3SG666SHgA==
 
-min-dom@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/min-dom/-/min-dom-3.1.3.tgz#6d3f4092439c80d13df52ac98d6a7d5fe92bfdbd"
-  integrity sha512-Lbi1NZjLV9Hg6/bEe2Lfk2Fzsv1MwheR61whqTLP+FxLndYo9TxpksEgM5Kr1khjfCtFTMr0waeEfwIpStkRdw==
+min-dash@^4.0.0, min-dash@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/min-dash/-/min-dash-4.1.1.tgz#09b85a5e1d0189ce02a4ec416180aa85db06451b"
+  integrity sha512-r+Z6vxXLSGr+otyCPx9NKPCSixw7LdfZREPTmqfd2a/d5D6w4NCdOxRJs+HyFO6v2pQkyHroGSiINWECK+OWPg==
+
+min-dom@^4.0.2, min-dom@^4.0.3, min-dom@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/min-dom/-/min-dom-4.1.0.tgz#ecbf9a2d0412ffe4ddc14253d65d15b47b6b4bf8"
+  integrity sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==
   dependencies:
-    component-event "^0.1.4"
-    domify "^1.3.1"
-    indexof "0.0.1"
-    matches-selector "^1.2.0"
+    component-event "^0.2.1"
+    domify "^1.4.1"
+    min-dash "^4.0.0"
 
 mini-css-extract-plugin@0.11.3:
   version "0.11.3"
@@ -8435,21 +8447,21 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moddle-xml@^9.0.5:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/moddle-xml/-/moddle-xml-9.0.5.tgz#01acc2450637c4bc9914b56c760b0a5cba5785a5"
-  integrity sha512-1t9N35ZMQZTYZmRDoh1mBVd0XwLB34BkBywNJ0+YlLLYxaDBjFR/I+fqwsY746ayYPBz6yNRg8JpLyFgNF+eHg==
+moddle-xml@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/moddle-xml/-/moddle-xml-10.1.0.tgz#8c2a1b73c73cc8915182d5374857c43ba482c7a5"
+  integrity sha512-erWckwLt+dYskewKXJso9u+aAZ5172lOiYxSOqKCPTy7L/xmqH1PoeoA7eVC7oJTt3PqF5TkZzUmbjGH6soQBg==
   dependencies:
-    min-dash "^3.5.2"
-    moddle "^5.0.2"
+    min-dash "^4.0.0"
+    moddle "^6.0.0"
     saxen "^8.1.2"
 
-moddle@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/moddle/-/moddle-5.0.2.tgz#9768320698be636711a29101c82fd361e3d90253"
-  integrity sha512-nBEyKt7sDw6MlM6e85lTCEXButw+p7hubEoRo/JyX+dBzDcGjDoktPuby9QE+ylW1ABZqNvRy8pK0h+23tIW2g==
+moddle@^6.0.0:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/moddle/-/moddle-6.2.3.tgz#03ff1e57633ce287d28cdf276d6ad20741302f69"
+  integrity sha512-bLVN+ZHL3aKnhxc19XtjUfvdJsS3EsiEJC7bT6YPD11qYmTzvsxrGgyYz1Ouof7TZuGw0lDJ1OLmEnxcpQWk3Q==
   dependencies:
-    min-dash "^3.0.0"
+    min-dash "^4.0.0"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -9912,6 +9924,11 @@ postcss@^8.1.0:
     colorette "^1.2.1"
     nanoid "^3.1.20"
     source-map "^0.6.1"
+
+preact@^10.11.2:
+  version "10.15.1"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.15.1.tgz#a1de60c9fc0c79a522d969c65dcaddc5d994eede"
+  integrity sha512-qs2ansoQEwzNiV5eAcRT1p1EC/dmEzaATVDJNiB3g2sRDWdA7b7MurXdJjB2+/WQktGWZwxvDrnuRFbWuIr64g==
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -11654,10 +11671,10 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-svg@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/tiny-svg/-/tiny-svg-2.2.2.tgz#9d9825c2e0ccb5e259bb1ae7d7ac79194e086657"
-  integrity sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg==
+tiny-svg@^3.0.0, tiny-svg@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/tiny-svg/-/tiny-svg-3.0.1.tgz#1cb79297b87abbc921396064098cbd08c3c34ea6"
+  integrity sha512-P8T4iwiW1t95vpHVHqrD36Brn7TqFYCPSHIWk9WLJtYK1X4aDd+5cgqcAADIWSjf1/i5idKnpCh9mim8hEdRBg==
 
 tiny-warning@^1.0.2:
   version "1.0.3"


### PR DESCRIPTION
This PR is mainly a fix for issue #6.
The problems fixed in this PR:
- The extentionType was trying to match "camunda:executionListener", but it should be "camunda:ExecutionListener". camunda:ExecutionListener were not displayed
- the executionListener doesn't have a "expression"-Property. You have to iterate over the fields to get the field with the expression property
- The extensionElements array can also not have a value property (Reading property of undefined)
- Use createTheme instead of createMultiTheme (deprecated)
- Use key in jsx list